### PR TITLE
Make it possible to run linter without config file

### DIFF
--- a/lib/linter-slim-lint.js
+++ b/lib/linter-slim-lint.js
@@ -25,10 +25,12 @@ module.exports = {
 
         this.path = textEditor.getPath();
         this.config = helpers.find(this.path, atom.config.get(CONFIG_KEY));
+        this.parameters = [];
 
-        if (!this.config) {
-          atom.notifications.addError('linter-slim-lint: Invalid config file!', { dismissable: true });
-          return [];
+        if (this.config) {
+          this.parameters.push('-c', this.config, this.path);
+        } else {
+          this.parameters.push(this.path);
         }
 
         return new Promise((resolve, reject) => {
@@ -36,7 +38,7 @@ module.exports = {
 
           helpers.exec(
             this.command,
-            ['-c', this.config, this.path], {
+            this.parameters, {
               stream: 'stdout',
               ignoreExitCode: true,
               throwOnStdErr: false


### PR DESCRIPTION
For the moment you cannot run `slim-lint` without a config file (`.slim-lint.yml` by default), but it seems to be too strict, so I've made it possible to run linter without a config file.