### PR TITLE
Add link to the result

### DIFF
--- a/lib/linter-slim-lint.js
+++ b/lib/linter-slim-lint.js
@@ -6,6 +6,7 @@ const helpers = require('atom-linter');
 
 const CONFIG_KEY = 'linter-slim-lint.config';
 const COMMAND_KEY = 'linter-slim-lint.command';
+const URL_BASE = 'https://github.com/sds/slim-lint/blob/master/lib/slim_lint/linter/README.md'
 
 module.exports = {
   activate() {
@@ -51,7 +52,7 @@ module.exports = {
 
               let lineNumber = parseInt(result[1], 10) - 1;
               let range = helpers.rangeFromLineNumber(textEditor, lineNumber);
-              let htmlMessage = '<span class="badge badge-flexible eslint">' + result[3] + '</span> ' + result[4];
+              let htmlMessage = `${result[3]}: ${result[4]} (<a href="${URL_BASE}#${result[3].toLowerCase()}">${result[3]}</a>)`;
 
               results.push({
                 type: result[2] === 'E' ? 'Error' : 'Warning',


### PR DESCRIPTION
I've add links to the page for the explanation for offensivenesses, and changed the layout a bit to make them similar to the results of popular [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) .

<img width="638" alt="ss" src="https://cloud.githubusercontent.com/assets/333180/20425753/574e7c06-adbf-11e6-8837-ae5ffeb916f3.png">
