### PR TITLE
Changes for Linter v2

### DIFF
--- a/lib/linter-slim-lint.js
+++ b/lib/linter-slim-lint.js
@@ -17,7 +17,7 @@ module.exports = {
       name: 'slim-lint',
       grammarScopes: ['text.slim'],
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
 
       lint: textEditor => {
         let buffer = textEditor.getBuffer();

--- a/lib/linter-slim-lint.js
+++ b/lib/linter-slim-lint.js
@@ -21,8 +21,8 @@ module.exports = {
 
       lint: textEditor => {
         let buffer = textEditor.getBuffer();
-        if (buffer.isModified()) return;
-        if (buffer.isEmpty()) return;
+        if (buffer.isModified()) return null;
+        if (buffer.isEmpty()) return null;
 
         this.path = textEditor.getPath();
         this.config = helpers.find(this.path, atom.config.get(CONFIG_KEY));

--- a/lib/linter-slim-lint.js
+++ b/lib/linter-slim-lint.js
@@ -66,7 +66,7 @@ module.exports = {
               let htmlMessage = `${result[4]} (${docLink})`;
 
               results.push({
-                type: result[2] === 'E' ? 'Error' : 'Warning',
+                severity: result[2] === 'E' ? 'error' : 'warning',
                 html: htmlMessage,
                 range: range,
                 filePath: textEditor.getPath()


### PR DESCRIPTION
Hello! Thank you for putting together this slim linter plugin. After upgrading [linter](https://atom.io/packages/linter) to v2 I started seeing a warning in Atom.

```
[Linter] Invalid Linter Result received
These issues were encountered while processing messages from a linter named 'slim-lint'
  • Linter Result must be an Array
```

I followed the steps in [Upgrading to Standard Linter v2](http://steelbrain.me/linter/guides/upgrading-to-standard-linter-v2.html) to update the code to the new standards and the warning went away.

There are two other changes that I could not get to work, so I left them as is for the time being. 

- Replace `html` with `description`
- Replace `filePath` and `range` with `location`
